### PR TITLE
Potential fix for code scanning alert no. 34: Clear-text logging of sensitive information

### DIFF
--- a/apps/server/src/utils/sanitizer.ts
+++ b/apps/server/src/utils/sanitizer.ts
@@ -59,7 +59,7 @@ class Sanitizer {
     } else if (value === null) {
       return null;
     }
-    logger.error(`Encountered invalid type '${typeof value}' with content: ${JSON.stringify(value)}`);
+    logger.error(`Encountered invalid type '${typeof value}'`);
     throw new BadRequestError();
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/caganseyrek/WalletTuner/security/code-scanning/34](https://github.com/caganseyrek/WalletTuner/security/code-scanning/34)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. The best way to fix this issue without changing existing functionality is to avoid logging the content of the value when an invalid type is encountered. Instead, we can log a generic message indicating the presence of an invalid type without including the actual content.

We will modify the logger.error call on line 62 in `apps/server/src/utils/sanitizer.ts` to remove the content of the value from the log message. This change will ensure that sensitive information is not exposed in the logs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
